### PR TITLE
Update naming typos to refer to CUDA instead of other docsets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This docset is to be used with [Dash for Mac](http://kapeli.com/dash), or [Zeal 
 
 ## Basic Installation
 
-* If you plan on using it with **Dash**, just copy the [CUDA]() provided to '/Users/username/Library/Application Support/Dash/Docsets/'. Visit [Dash](http://kapeli.com/dash) website for more info.
+* If you plan on using it with **Dash**, `create_docset_orig.sh` will copy the [CUDA]() docset to '/Users/username/Library/Application Support/Dash/Docsets/' automatically. Visit [Dash](http://kapeli.com/dash) website for more info.
 * If you're going to use it with **Zeal** you'll find where to store the [CUDA]() in the application 'Options' menu. Visit [their Github page](https://github.com/jkozera/zeal) for more info. 
 
 
@@ -20,8 +20,8 @@ Basically, execute the following commands:
 
 ```
 git clone https://github.com/simioprg/dash-CUDA.git
-cd dash-foundation
-./create_docset.sh
+cd dash-CUDA
+./create_docset_orig.sh
 cd ..
 rm -rf dash-foundation
 ```

--- a/create_docset_orig.sh
+++ b/create_docset_orig.sh
@@ -13,9 +13,8 @@ echo -e "$(tput setaf 2)--> Downloading the documentation of '$DOCSET_NAME'$(tpu
       --restrict-file-names=windows  \
       --domains nvidia.com --no-parent http://docs.nvidia.com/cuda 2>&1 | egrep -i "%|Saving to"
 
-cp -r docs.phalconphp.com/en/latest/* "${DOCSET_NAME}.docset/Contents/Resources/Documents/"
-mv docs.phalconphp.com/en/latest/* "${DOCSET_NAME}.docset/Contents/Resources/Documents/"
-rm -rf docs.phalconphp.com
+cp -r docs.nvidia.com/cuda/* "${DOCSET_NAME}.docset/Contents/Resources/Documents/"
+mv docs.nvidia.com/cuda/* "${DOCSET_NAME}.docset/Contents/Resources/Documents/"
 
 # CREATE PROPERTY LIST...
 echo -e "$(tput setaf 2)--> Creating the Property List...$(tput sgr0)"
@@ -45,7 +44,7 @@ EOF
 
 # PARSE & CLEAN THE HTML DOCUMENTATION. FILL THE DB...
 echo -e "$(tput setaf 2)--> Parsing the documentation...$(tput sgr0)"
-php phalcon_parser.php ${DOCSET_NAME}.docset ${DOCSET_NAME}.docset/Contents/Resources/Documents
+php cuda_parser.php ${DOCSET_NAME}.docset ${DOCSET_NAME}.docset/Contents/Resources/Documents
 
 # AVOID HORIZONTAL SCROLLING BY DIMINISHING MIN-WIDTH OF HTLM DOC
 for stylesheet in `find ${DOCSET_NAME}.docset/Contents/Resources/Documents -name *.css`; do


### PR DESCRIPTION
Thanks for making this!

I got a little confused when an empty 9Kb docset was created. Also the `Rakefile` which seemed to be missing a few steps.

The changes in this PR got docset generation to work for me. Next intimidating step: [indexing it](https://kapeli.com/docsets#createsqlite)!
